### PR TITLE
[ED-7248] increase operational log verbosity

### DIFF
--- a/k8s/utils.go
+++ b/k8s/utils.go
@@ -15,9 +15,9 @@ var (
 	sliceRe = regexp.MustCompile(`([^\[\]]+)\[(\d+)\]$`)
 )
 
-func SetStructFieldValue(o any, path []string, setValue any) error {
+func CompareAndUpdateStructField(o any, path []string, setValue string) (bool, error) {
 	if len(path) == 0 {
-		return errors.New("no path specified")
+		return false, errors.New("no path specified")
 	}
 	fields := structs.Fields(o)
 	lookForTag := path[0]
@@ -27,7 +27,7 @@ func SetStructFieldValue(o any, path []string, setValue any) error {
 		var err error
 		sliceIndex, err = strconv.ParseUint(match[2], 10, 64)
 		if err != nil {
-			return fmt.Errorf("failed to parse slice index '%s' to uint64, err: %v", match[2], err)
+			return false, fmt.Errorf("failed to parse slice index '%s' to uint64, err: %v", match[2], err)
 		}
 		wantSlice = true
 		lookForTag = match[1]
@@ -40,19 +40,22 @@ func SetStructFieldValue(o any, path []string, setValue any) error {
 		}
 		if len(path) == 1 {
 			if wantSlice {
-				return errors.New("directly setting a slice element is not supported")
+				return false, errors.New("directly setting a slice element is not supported")
 			}
-			return f.Set(setValue)
+			if setValue == f.Value().(string) {
+				return false, nil
+			}
+			return true, f.Set(setValue)
 		}
 		var obj any = f.Value()
 		if wantSlice {
 			if f.Kind() != reflect.Slice {
-				return fmt.Errorf("expected '%s' to be a slice, got %s instead", lookForTag, f.Kind().String())
+				return false, fmt.Errorf("expected '%s' to be a slice, got %s instead", lookForTag, f.Kind().String())
 			}
 			obj = reflect.ValueOf(f.Value()).Index(int(sliceIndex)).Addr().Interface()
 		}
 		newPath := path[1:]
-		return SetStructFieldValue(obj, newPath, setValue)
+		return CompareAndUpdateStructField(obj, newPath, setValue)
 	}
-	return fmt.Errorf("could not find field with JSON tag %s in object %+v", lookForTag, o)
+	return false, fmt.Errorf("could not find field with JSON tag %s in object %+v", lookForTag, o)
 }

--- a/k8s/utils_test.go
+++ b/k8s/utils_test.go
@@ -9,98 +9,82 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestSetStructFieldValue(t *testing.T) {
+func TestCompareAndUpdateStructField(t *testing.T) {
 	tests := []struct {
 		desc        string
 		object      any
 		path        []string
-		updateValue any
+		updateValue string
 		wantObject  any
+		wantUpdated bool
 	}{
 		{
-			desc: "Update K8s daemonset images",
-			object: &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "edgedelta",
-					Namespace:       "edgedelta",
-					UID:             "ef61b019-aaaa-bbbb-cccc-2ddd26e1dbca",
-					ResourceVersion: "231953",
-				},
-				Spec: appsv1.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									Command: []string{"/bin/edgedelta"},
-									Env: []v1.EnvVar{
-										{
-											Name: "ED_API_KEY",
-											ValueFrom: &v1.EnvVarSource{
-												SecretKeyRef: &v1.SecretKeySelector{
-													Key: "ed-api-key",
-													LocalObjectReference: v1.LocalObjectReference{
-														Name: "ed-api-key",
-													},
-												},
-											},
-										},
-									},
-									Image:           "gcr.io/edgedelta/agent:v0.1.47",
-									ImagePullPolicy: v1.PullAlways,
-									Name:            "edgedelta",
-								},
-							},
-						},
-					},
-				},
-			},
+			desc:        "Update K8s daemonset images",
+			object:      daemonsetWithImage("gcr.io/edgedelta/agent:v0.1.47"),
 			path:        []string{"spec", "template", "spec", "containers[0]", "image"},
 			updateValue: "gcr.io/edgedelta/agent:v0.1.49",
-			wantObject: &appsv1.DaemonSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "edgedelta",
-					Namespace:       "edgedelta",
-					UID:             "ef61b019-aaaa-bbbb-cccc-2ddd26e1dbca",
-					ResourceVersion: "231953",
-				},
-				Spec: appsv1.DaemonSetSpec{
-					Template: v1.PodTemplateSpec{
-						Spec: v1.PodSpec{
-							Containers: []v1.Container{
-								{
-									Command: []string{"/bin/edgedelta"},
-									Env: []v1.EnvVar{
-										{
-											Name: "ED_API_KEY",
-											ValueFrom: &v1.EnvVarSource{
-												SecretKeyRef: &v1.SecretKeySelector{
-													Key: "ed-api-key",
-													LocalObjectReference: v1.LocalObjectReference{
-														Name: "ed-api-key",
-													},
-												},
-											},
-										},
-									},
-									Image:           "gcr.io/edgedelta/agent:v0.1.49",
-									ImagePullPolicy: v1.PullAlways,
-									Name:            "edgedelta",
-								},
-							},
-						},
-					},
-				},
-			},
+			wantUpdated: true,
+			wantObject:  daemonsetWithImage("gcr.io/edgedelta/agent:v0.1.49"),
+		},
+		{
+			desc:        "Update K8s daemonset images",
+			object:      daemonsetWithImage("gcr.io/edgedelta/agent:v0.1.47"),
+			path:        []string{"spec", "template", "spec", "containers[0]", "image"},
+			updateValue: "gcr.io/edgedelta/agent:v0.1.47",
+			wantUpdated: false,
+			wantObject:  daemonsetWithImage("gcr.io/edgedelta/agent:v0.1.47"),
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			if err := SetStructFieldValue(tc.object, tc.path, tc.updateValue); err != nil {
+			updated, err := CompareAndUpdateStructField(tc.object, tc.path, tc.updateValue)
+			if err != nil {
 				t.Fatal(err)
+			}
+			if updated != tc.wantUpdated {
+				t.Fatalf("Wanted 'updated' return value as %t, got %t instead", tc.wantUpdated, updated)
 			}
 			if diff := cmp.Diff(tc.wantObject, tc.object); diff != "" {
 				t.Errorf("Objects mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func daemonsetWithImage(image string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "edgedelta",
+			Namespace:       "edgedelta",
+			UID:             "ef61b019-aaaa-bbbb-cccc-2ddd26e1dbca",
+			ResourceVersion: "231953",
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Command: []string{"/bin/edgedelta"},
+							Env: []v1.EnvVar{
+								{
+									Name: "ED_API_KEY",
+									ValueFrom: &v1.EnvVarSource{
+										SecretKeyRef: &v1.SecretKeySelector{
+											Key: "ed-api-key",
+											LocalObjectReference: v1.LocalObjectReference{
+												Name: "ed-api-key",
+											},
+										},
+									},
+								},
+							},
+							Image:           image,
+							ImagePullPolicy: v1.PullAlways,
+							Name:            "edgedelta",
+						},
+					},
+				},
+			},
+		},
 	}
 }

--- a/updater.go
+++ b/updater.go
@@ -98,12 +98,12 @@ func (u *Updater) Run(ctx context.Context) error {
 			errors.Addf("failed to get latest applicable tag from API for entity with ID %s, err: %v", entity.ID, err)
 			continue
 		}
+		log.Info().Msgf("Latest applicable tag from API: %+v", res)
 		for _, path := range entity.K8sPaths {
 			if err := u.k8sCli.SetResourceKeyValue(ctx, path, res.URL); err != nil {
 				errors.Addf("failed to set K8s resource spec key/value for entity with ID %s (path: %s, value: %s), err: %v", entity.ID, path, res.URL, err)
 				continue
 			}
-			log.Info().Msgf("Updated version of resource with path %s to %s", path, res.URL)
 		}
 	}
 	return errors.ErrorOrNil()


### PR DESCRIPTION
## Summary

Added log lines for events:
- current daemonset version
- version response from the API
- whether the updater decided to update or not

Fixes #[ED-7248](https://edgedelta.atlassian.net/browse/ED-7248)