### PR TITLE
Update log timestamp format to milliseconds

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -15,7 +15,7 @@ var (
 )
 
 func init() {
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixNano
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
 	zerolog.TimestampFieldName = "timestamp"
 	zerolog.MessageFieldName = "raw"
 


### PR DESCRIPTION
## Summary

- Updated log timestamp format from nanoseconds to milliseconds
- This PR solves the agent updater self log bug in log search in the dashboard

Fixes #[ED-7466](https://edgedelta.atlassian.net/browse/ED-7466)