### PR TITLE
Feat: Version update pass on empty latest tag endpoint response

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/edgedelta/updater/core"
 	"github.com/edgedelta/updater/core/compressors"
@@ -54,9 +53,6 @@ func (c *Client) GetLatestApplicableTag(id string) (*core.LatestTagResponse, err
 	}
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return nil, fmt.Errorf("status code is not in the expected range (%d), response body: %q", res.StatusCode, string(data))
-	}
-	if strings.TrimSpace(string(data)) == "null" {
-		return nil, nil
 	}
 	var r core.LatestTagResponse
 	if err := json.Unmarshal(data, &r); err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/edgedelta/updater/core"
 	"github.com/edgedelta/updater/core/compressors"
@@ -53,6 +54,9 @@ func (c *Client) GetLatestApplicableTag(id string) (*core.LatestTagResponse, err
 	}
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return nil, fmt.Errorf("status code is not in the expected range (%d), response body: %q", res.StatusCode, string(data))
+	}
+	if strings.TrimSpace(string(data)) == "null" {
+		return nil, nil
 	}
 	var r core.LatestTagResponse
 	if err := json.Unmarshal(data, &r); err != nil {

--- a/updater.go
+++ b/updater.go
@@ -127,7 +127,7 @@ func (u *Updater) Run(ctx context.Context) error {
 			errors.Addf("failed to get latest applicable tag from API for entity with ID %s, err: %v", entity.ID, err)
 			continue
 		}
-		if res == nil {
+		if res.Tag == "" {
 			log.Info("No applicable tag found for entity with ID %s", entity.ID)
 			continue
 		}

--- a/updater.go
+++ b/updater.go
@@ -127,6 +127,10 @@ func (u *Updater) Run(ctx context.Context) error {
 			errors.Addf("failed to get latest applicable tag from API for entity with ID %s, err: %v", entity.ID, err)
 			continue
 		}
+		if res == nil {
+			log.Info("No applicable tag found for entity with ID %s", entity.ID)
+			continue
+		}
 		log.Info("Latest applicable tag from API: %+v", res)
 		for _, path := range entity.K8sPaths {
 			if err := u.k8sCli.SetResourceKeyValue(ctx, path, res.URL); err != nil {


### PR DESCRIPTION
## Summary

This PR adds the functionality to check for empty (`null`) API responses in `GetLatestApplicableTag` function and pass the agent update process if there were no tag data received.