### PR TITLE
[OBSUB-21] agent-updater add missing statefulset handling to image update

### DIFF
--- a/core/constants.go
+++ b/core/constants.go
@@ -3,13 +3,15 @@ package core
 type K8sResourceKind string
 
 const (
-	K8sDaemonset  K8sResourceKind = "ds"
-	K8sDeployment K8sResourceKind = "deploy"
+	K8sDaemonset   K8sResourceKind = "ds"
+	K8sDeployment  K8sResourceKind = "deploy"
+	K8sStatefulset K8sResourceKind = "sts"
 )
 
 var (
 	SupportedK8sResourceKinds = map[K8sResourceKind]bool{
-		K8sDaemonset:  true,
-		K8sDeployment: true,
+		K8sDaemonset:   true,
+		K8sDeployment:  true,
+		K8sStatefulset: true,
 	}
 )


### PR DESCRIPTION
## Summary
- agent-updater could not manage the image versions for StatefulSets


Fixes #[OBSUB-21](https://edgedelta.atlassian.net/browse/OBSUB-21)

## Testing
Tests are demonstrated in https://github.com/edgedelta/edgedelta/pull/12654