### PR TITLE
[OBSUB-18] add entity query param while sending requests to versioning service #api

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -27,11 +27,20 @@ func NewClient(conf *core.APIConfig) *Client {
 	return &Client{cl: cl, conf: conf}
 }
 
-func (c *Client) GetLatestApplicableTag(id string) (*core.LatestTagResponse, error) {
-	url, err := constructURLWithParams(
-		c.conf.BaseURL+c.conf.LatestTagEndpoint.Endpoint,
-		c.conf.LatestTagEndpoint.Params, nil,
-	)
+func (c *Client) GetLatestApplicableTag(id, name string) (*core.LatestTagResponse, error) {
+	params := &core.ParamConf{
+		QueryParams: map[string]string{
+			"entity": name,
+		},
+	}
+	if c.conf.LatestTagEndpoint.Params != nil {
+		for k, v := range c.conf.LatestTagEndpoint.Params.QueryParams {
+			params.QueryParams[k] = v
+		}
+	}
+
+	apiURL := fmt.Sprintf("%s%s", c.conf.BaseURL, c.conf.LatestTagEndpoint.Endpoint)
+	url, err := constructURLWithParams(apiURL, params, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct URL with params, err: %v", err)
 	}

--- a/core/types.go
+++ b/core/types.go
@@ -78,7 +78,7 @@ type LatestTagResponse struct {
 }
 
 type VersioningServiceClient interface {
-	GetLatestApplicableTag(entityID string) (*LatestTagResponse, error)
+	GetLatestApplicableTag(entityID, entityName string) (*LatestTagResponse, error)
 	GetPresignedLogUploadURL(logSize int) (string, error)
 	UploadLogs(lines []any) error
 	GetMetadata() (map[string]string, error)

--- a/updater.go
+++ b/updater.go
@@ -122,7 +122,7 @@ func (u *Updater) Run(ctx context.Context) error {
 	u.logRunningConfig()
 	errors := core.NewErrors()
 	for _, entity := range u.config.Entities {
-		res, err := u.apiCli.GetLatestApplicableTag(entity.ID)
+		res, err := u.apiCli.GetLatestApplicableTag(entity.ID, entity.ImageName)
 		if err != nil {
 			errors.Addf("failed to get latest applicable tag from API for entity with ID %s, err: %v", entity.ID, err)
 			continue


### PR DESCRIPTION
## Summary
- send entitiy names as query parameter to the /v1/versioning/latest API

Fixes #[OBSUB-18](https://edgedelta.atlassian.net/browse/OBSUB-18)

